### PR TITLE
Fix versions and add outputs.tf file

### DIFF
--- a/versions.tf
+++ b/versions.tf
@@ -1,7 +1,8 @@
 terraform {
   required_providers {
     aws = {
-      source = "hashicorp/aws"
+      source  = "hashicorp/aws"
+      version = ">= 3.20.0"
     }
   }
   required_version = ">= 0.13"


### PR DESCRIPTION
This PR fixes provider versions to use the correct minimum `aws` provider version.

It also adds an empty `outputs.tf` file to match the best practices for [module code structure](https://www.terraform-best-practices.com/code-structure#getting-started-with-structuring-of-terraform-configurations).

Once this is merged we can release v1.0.0 of this, so we can pin it as part of ministryofjustice/modernisation-platform#72.