### PR TITLE
Adding option to pass custom trust statements

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -1,0 +1,22 @@
+name: Generate Terraform README docs
+on:
+  workflow_dispatch:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  docs:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        ref: ${{ github.event.pull_request.head.ref }}
+
+    - name: Render terraform docs and push changes back to PR
+      uses: terraform-docs/gh-actions@v1.0.0
+      with:
+        working-dir: .
+        output-file: README.md
+        output-method: inject
+        git-push: "true"

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ module "cross-account-access" {
   role_name  = "CrossAccountAccess"
 }
 ```
-
+<!-- BEGIN_TF_DOCS -->
 ## Inputs
 
 | Name       | Description                  | Type   | Default                                  | Required |
@@ -26,6 +26,7 @@ module "cross-account-access" {
 ## Outputs
 
 None.
+<!-- BEGIN_TF_DOCS -->
 
 ## Looking for issues?
 

--- a/main.tf
+++ b/main.tf
@@ -27,7 +27,7 @@ data "aws_iam_policy_document" "assume-role-policy" {
 }
 
 data "aws_iam_policy_document" "combined-assume-role-policy" {
-  source_policy_documents = concat([data.aws_iam_policy_document.assume_role_policy.json], var.additional_trust_statements)
+  source_policy_documents = concat([data.aws_iam_policy_document.assume-role-policy.json], var.additional_trust_statements)
 }
 
 # IAM role to be assumed

--- a/main.tf
+++ b/main.tf
@@ -26,10 +26,14 @@ data "aws_iam_policy_document" "assume-role-policy" {
   }
 }
 
+data "aws_iam_policy_document" "combined-assume-role-policy" {
+  source_policy_documents = concat([data.aws_iam_policy_document.assume_role_policy.json], var.additional_trust_statements)
+}
+
 # IAM role to be assumed
 resource "aws_iam_role" "default" {
   name               = var.role_name
-  assume_role_policy = data.aws_iam_policy_document.assume-role-policy.json
+  assume_role_policy = data.aws_iam_policy_document.combined-assume-role-policy.json
 }
 
 # IAM role attached policy

--- a/variables.tf
+++ b/variables.tf
@@ -8,6 +8,11 @@ variable "additional_trust_roles" {
   default     = []
 }
 
+variable "additional_trust_statements" {
+  description = "Json attributes of additional iam policy documents to add to the trust policy"
+  default     = []
+}
+
 variable "role_name" {
   type        = string
   description = "Name of assumable role"


### PR DESCRIPTION
For usecases where an `sts:AssumeRole` principals need to be restricted via a condition such as SSO roles.