### PR TITLE
Issue/6991

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ No modules.
 | <a name="input_account_id"></a> [account\_id](#input\_account\_id) | Account ID to give access to | `string` | n/a | yes |
 | <a name="input_additional_trust_roles"></a> [additional\_trust\_roles](#input\_additional\_trust\_roles) | ARN of other roles to be passed as principals for sts:AssumeRole | `list(string)` | `[]` | no |
 | <a name="input_additional_trust_statements"></a> [additional\_trust\_statements](#input\_additional\_trust\_statements) | Json attributes of additional iam policy documents to add to the trust policy | `list(string)` | `[]` | no |
-| <a name="input_policy_arn"></a> [policy\_arn](#input\_policy\_arn) | Policy ARN for the assumable role. Defaults to arn:aws:iam::aws:policy/ReadOnlyAccess | `string` | `"arn:aws:iam::aws:policy/ReadOnlyAccess"` | no |
+| <a name="input_policy_arns"></a> [policy\_arns](#input\_policy\_arns) | One of more policy ARNs for the assumable role. Defaults to arn:aws:iam::aws:policy/ReadOnlyAccess | `list(string)` | <pre>[<br>  "arn:aws:iam::aws:policy/ReadOnlyAccess"<br>]</pre> | no |
 | <a name="input_role_name"></a> [role\_name](#input\_role\_name) | Name of assumable role | `string` | n/a | yes |
 
 ## Outputs

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ A simple Terraform module to configure an IAM role that is assumable from anothe
 module "cross-account-access" {
   source     = "github.com/ministryofjustice/modernisation-platform-terraform-cross-account-access"
   account_id = "123456789"
-  policy_arn = "arn:aws:iam::aws:policy/ReadOnlyAccess"
+  policy_arns = [ "arn:aws:iam::aws:policy/ReadOnlyAccess" ]
   role_name  = "CrossAccountAccess"
 }
 ```

--- a/main.tf
+++ b/main.tf
@@ -36,8 +36,9 @@ resource "aws_iam_role" "default" {
   assume_role_policy = data.aws_iam_policy_document.combined-assume-role-policy.json
 }
 
-# IAM role attached policy
+# IAM role attached policies
 resource "aws_iam_role_policy_attachment" "default" {
+  for_each   = toset(var.policy_arns)
   role       = aws_iam_role.default.id
-  policy_arn = var.policy_arn
+  policy_arn = each.value
 }

--- a/test/unit-test/main.tf
+++ b/test/unit-test/main.tf
@@ -1,6 +1,6 @@
 module "cross-account-access" {
   source     = "../../"
   account_id = data.aws_caller_identity.current.account_id
-  policy_arn = "arn:aws:iam::aws:policy/ReadOnlyAccess"
+  policy_arns = [ "arn:aws:iam::aws:policy/ReadOnlyAccess" ]
   role_name  = "CrossAccountAccess"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -20,8 +20,8 @@ variable "role_name" {
   description = "Name of assumable role"
 }
 
-variable "policy_arn" {
-  type        = string
-  description = "Policy ARN for the assumable role. Defaults to arn:aws:iam::aws:policy/ReadOnlyAccess"
-  default     = "arn:aws:iam::aws:policy/ReadOnlyAccess"
+variable "policy_arns" {
+  type        = list(string)
+  description = "One of more policy ARNs for the assumable role. Defaults to arn:aws:iam::aws:policy/ReadOnlyAccess"
+  default     = [ "arn:aws:iam::aws:policy/ReadOnlyAccess" ]
 }


### PR DESCRIPTION
The purpose of this change is to support the attachment of more than one policy. This is in the context where a single policy is insufficient to meet the requirement.