### PR TITLE
Add Dependabot Grouping

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,10 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    groups:
+      action-dependencies:
+        patterns:
+          - "*"
   - package-ecosystem: "terraform"
     directory: "/"
     schedule:
@@ -13,3 +17,7 @@ updates:
     directory: "/test"
     schedule:
       interval: "daily"
+    groups:
+      gomod-dependencies:
+        patterns:
+          - "*"


### PR DESCRIPTION
This PR updates the dependabot configuration to allow grouping for Github actions and Go dependencies.